### PR TITLE
Handle refs in arrays

### DIFF
--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -93,16 +93,9 @@ component name="OpenAPIParser" accessors="true" {
 	* @param [XPath]	The XPath to zoom the parsed document to during recursion
 	**/
 	public function parse( required struct APIDoc, required string XPath="" ){
-
 		setDocumentObject( getWirebox().getInstance( "OpenAPIDocument@SwaggerSDK" ).init( arguments.APIDoc, arguments.XPath) );
 
-		var Document = getDocumentObject().getDocument();
-
-		for( var key in Document ){
-			if( isSimpleValue( key ) ){
-				Document[ key ] = parseDocumentReferences( Document[ key ] );
-			}
-		}
+		parseDocumentReferences( getDocumentObject().getDocument() );
 
 		return this;
 	}


### PR DESCRIPTION
This lets you have the following syntax:
```json
{
    "parameters": [
        {
            "$ref": "/resources/apidocs/api-v1/_parameters/maxrows.json"
        }
    ]
}
```
which is valid Swagger (https://swagger.io/docs/specification/describing-parameters/#common-for-various-paths)