### PR TITLE
Remove empty externalDocs object as the default value

### DIFF
--- a/models/OpenAPI/Util.cfc
+++ b/models/OpenAPI/Util.cfc
@@ -35,11 +35,7 @@ component name="OpenAPIUtil" accessors="true" {
 			{ "paths"           : structNew( "ordered" ) },
 			{ "components"      : structNew( "ordered" ) },
 			{ "security" 		: [] },
-			{ "tags" 			: [] },
-			{ "externalDocs" 	: {
-				"description" 	: "",
-				"url" 			: ""
-			} }
+			{ "tags" 			: [] }
 		];
 
 		for( var templateDefault  in  templateDefaults ){
@@ -68,12 +64,6 @@ component name="OpenAPIUtil" accessors="true" {
 			{
 				"responses"  : {
 					"default": descMap
-				}
-			},
-			{
-				"externalDocs" : {
-					"description" 	: "",
-					"url" 			: ""
 				}
 			}
 		];


### PR DESCRIPTION
Many validation and linting tools do not allow empty strings as valid urls or descriptions.  Additionally, `externalDocs` is hardly
used.  Users may add it back in if they would like, but the default will be to omit it.