### PR TITLE
Allow for refs that contain refs

### DIFF
--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -132,7 +132,7 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 			//handle top-level values, if they exist
-			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference( DocItem[ "$ref" ] );
+			if( structKeyExists( DocItem, "$ref" ) ) return parseDocumentReferences( fetchDocumentReference( DocItem[ "$ref" ] ).getNormalizedDocument() );
 
 			for( var key in DocItem){
 
@@ -142,7 +142,7 @@ component name="OpenAPIParser" accessors="true" {
 					structKeyExists( DocItem[ key ], "$ref" )
 				) {
 
-					DocItem[ key ] = fetchDocumentReference( DocItem[ key ][ "$ref" ] );
+					DocItem[ key ] = parseDocumentReferences( fetchDocumentReference( DocItem[ key ][ "$ref" ] ).getNormalizedDocument() );
 
 				} else if( isStruct( DocItem[ key ] ) ||  isArray( DocItem[ key ] ) ){
 
@@ -233,7 +233,7 @@ component name="OpenAPIParser" accessors="true" {
 
 		}
 
-		return parseDocumentReferences( ReferenceDocument.getNormalizedDocument() );
+		return ReferenceDocument;
 	}
 
 	/**

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -132,7 +132,7 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 			//handle top-level values, if they exist
-			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference(DocItem[ "$ref" ]);
+			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference( DocItem[ "$ref" ] );
 
 			for( var key in DocItem){
 
@@ -233,7 +233,7 @@ component name="OpenAPIParser" accessors="true" {
 
 		}
 
-		return ReferenceDocument;
+		return parseDocumentReferences( ReferenceDocument.getNormalizedDocument() );
 	}
 
 	/**


### PR DESCRIPTION
We do this by parsing the fetched document references for refs inside `fetchDocumentReference`.