### PR TITLE
Patch/revert auto normalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Start ${{ matrix.cfengine }} Server
         working-directory: ./test-harness
         run: |
+          echo "matrix.cfengine=${{ matrix.cfengine }}" > ./.env
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
           curl http://127.0.0.1:60299
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,6 @@ jobs:
         working-directory: ./test-harness
         run: |
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
-          # Install Adobe 2021 cfpm modules
-          if [[ "${{ matrix.cfengine }}" == "adobe@2021" ]] ; then
-            box run-script install:2021
-          fi
           curl http://127.0.0.1:60299
 
       - name: Run Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Start ${{ matrix.cfengine }} Server
         working-directory: ./test-harness
         run: |
-          printenv
+          echo "matrix.cfengine=${{ matrix.cfengine }}" > ./.env
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
           curl http://127.0.0.1:60299
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Start ${{ matrix.cfengine }} Server
         working-directory: ./test-harness
         run: |
+          printenv
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
           curl http://127.0.0.1:60299
 

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -141,8 +141,8 @@ component name="OpenAPIParser" accessors="true" {
 					&&
 					structKeyExists( DocItem[ key ], "$ref" )
 				) {
-					var parsedItem = parseDocumentReferences( fetchDocumentReference( DocItem[ key ][ "$ref" ] ) );
-					DocItem[ key ] = isInstanceOf( parsedItem, "Parser" ) ? parsedItem.getNormalizedDocument() : parsedItem;
+
+					DocItem[ key ] = parseDocumentReferences( fetchDocumentReference( DocItem[ key ][ "$ref" ] ).getNormalizedDocument() );
 
 				} else if( isStruct( DocItem[ key ] ) ||  isArray( DocItem[ key ] ) ){
 

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -132,7 +132,7 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 			//handle top-level values, if they exist
-			if( structKeyExists( DocItem, "$ref" ) ) return parseDocumentReferences( fetchDocumentReference( DocItem[ "$ref" ] ).getNormalizedDocument() );
+			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference( DocItem[ "$ref" ] );
 
 			for( var key in DocItem){
 
@@ -142,7 +142,7 @@ component name="OpenAPIParser" accessors="true" {
 					structKeyExists( DocItem[ key ], "$ref" )
 				) {
 
-					DocItem[ key ] = parseDocumentReferences( fetchDocumentReference( DocItem[ key ][ "$ref" ] ).getNormalizedDocument() );
+					DocItem[ key ] = fetchDocumentReference( DocItem[ key ][ "$ref" ] );
 
 				} else if( isStruct( DocItem[ key ] ) ||  isArray( DocItem[ key ] ) ){
 
@@ -233,7 +233,7 @@ component name="OpenAPIParser" accessors="true" {
 
 		}
 
-		return ReferenceDocument;
+		return parseDocumentReferences( ReferenceDocument.getNormalizedDocument() );
 	}
 
 	/**

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -132,7 +132,7 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 			//handle top-level values, if they exist
-			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference( DocItem[ "$ref" ] );
+			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference(DocItem[ "$ref" ]);
 
 			for( var key in DocItem){
 
@@ -233,7 +233,7 @@ component name="OpenAPIParser" accessors="true" {
 
 		}
 
-		return parseDocumentReferences( ReferenceDocument.getNormalizedDocument() );
+		return ReferenceDocument;
 	}
 
 	/**

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,8 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "cfpm":"echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\"' | run",
-        "cfpm:install":"echo '\".engine/adobe2021/WEB-INF/cfusion/bin/cfpm.sh\" install ${1}' | run",
-        "install:2021":"run-script cfpm:install zip"
+        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip"
     }
 }

--- a/test-harness/server-adobe@2021.json
+++ b/test-harness/server-adobe@2021.json
@@ -15,5 +15,8 @@
             "/moduleroot/swagger-sdk":"../"
         }
     },
-    "openBrowser":"false"
+    "openBrowser": false,
+    "scripts":{
+        "onServerInstall":"cfpm install zip"
+    }
 }

--- a/test-harness/server-adobe@2021.json
+++ b/test-harness/server-adobe@2021.json
@@ -9,14 +9,11 @@
             "port":"60299"
         },
         "rewrites":{
-            "enable":"true"
+            "enable":true
         },
         "aliases":{
             "/moduleroot/swagger-sdk":"../"
         }
     },
-    "openBrowser": false,
-    "scripts":{
-        "onServerInstall":"cfpm install zip"
-    }
+    "openBrowser":true
 }


### PR DESCRIPTION
Reverts the commits which changed the normalization strategy for parsing nested documents.  These break the existing test specs and also have the potential to cause regressions downstream in other modules which use the SDK