### PR TITLE
Patch/simplify acf2021 setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Start ${{ matrix.cfengine }} Server
         working-directory: ./test-harness
         run: |
-          echo "matrix.cfengine=${{ matrix.cfengine }}" > ./.env
           box server start serverConfigFile="server-${{ matrix.cfengine }}.json" --noSaveSettings --debug
           curl http://127.0.0.1:60299
 

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"! assertEqual ${matrix.cfengine} adobe@2021 || cfpm install zip"
+        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 || cfpm install zip ; echo 'Engine prerequisites met'"
     }
 }

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 || cfpm install zip ; echo 'Engine prerequisites met'"
+        "onServerInstall":"( assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip ); echo 'engine check complete'"
     }
 }

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip"
+        "onServerInstall":"echo `assertEqual '${matrix.cfengine}' 'adobe@2021' && cfpm install zip`"
     }
 }

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"( assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip ); echo 'engine check complete'"
+        "onServerInstall":"cfpm install zip"
     }
 }

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip"
+        "onServerInstall":"! assertEqual ${matrix.cfengine} adobe@2021 || cfpm install zip"
     }
 }

--- a/test-harness/box.json
+++ b/test-harness/box.json
@@ -20,6 +20,6 @@
         "runner":"http://localhost:60299/tests/runner.cfm"
     },
     "scripts":{
-        "onServerInstall":"cfpm install zip"
+        "onServerInstall":"assertEqual ${matrix.cfengine} adobe@2021 && cfpm install zip"
     }
 }


### PR DESCRIPTION
This simplifies the setup for ACF 2021.  The previous implementation did not ensure the ZIP module was loaded by the time the tests were run because cfpm was running after the server had started.

The other commits for this were included in PR#12