### PR TITLE
Normalize the document object if Parser so it can be extended

### DIFF
--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -219,6 +219,12 @@ component name="OpenAPIParser" accessors="true" {
         };
         objects.each( function( item, index ) {
             if ( isStruct( item ) ) {
+			
+				// If `item` is an instance of Parser, we need to flattin it to a CFML struct
+                if ( isInstanceOf( item, "Parser" ) ) {
+                    item = item.getNormalizedDocument();
+                }
+			
                 item.each( function( key, value ) {
 
                     if (


### PR DESCRIPTION
Cannot call the method `each()` on a `Parser` object. It must be normalized first. See https://github.com/coldbox-modules/swagger-sdk/issues/20