### PR TITLE
Parser Fixes and Coldbox RESTful App Tests

### DIFF
--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -280,14 +280,8 @@ component name="OpenAPIParser" accessors="true" {
 	**/
 	private function fetchDocumentReference( required string $ref ){
 
-        /* if ( $ref == chr( 35 ) & chr( 35 ) & "/components/requestBodies/PostBody" ) {
-            writeDump( var=$ref, output="console" );
-        } */
-        
-        
         // double pound ## means we want to preserve the swagger $ref pointer (just remove the extra #)
         if( left( $ref, 2 ) == chr( 35 ) & chr( 35 ) ){
-            writeDump( var=right( $ref, ( len( $ref ) - 1 ) ), output="console" );
             return  { "$ref": right( $ref, ( len( $ref ) - 1 ) ) };
 		//resolve internal refrences before looking for externals
         } else if( left( $ref, 1 ) == chr( 35 )){

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -137,6 +137,14 @@ component name="OpenAPIParser" accessors="true" {
 
 			for( var key in DocItem){
 
+                // If `DocItem[ key ]` is an instance of Parser, we need to flattin it to a CFML struct
+				if ( 
+					isStruct( DocItem[ key ] ) && 
+					findNoCase( "Parser", getMetaData( DocItem[ key ] ).name ) 
+				) {
+					DocItem[ key ] = DocItem[ key ].getNormalizedDocument();
+				}
+                
                 if (
 					isStruct( DocItem[ key ] )
 					&&

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -264,8 +264,11 @@ component name="OpenAPIParser" accessors="true" {
 	**/
 	private function fetchDocumentReference( required string $ref ){
 
+        // double pound ## means we want to preserve the swagger $ref pointer (just remove the extra #)
+        if( left( $ref, 2 ) == chr( 35 ) & chr( 35 ) ){
+            return  { "$ref": right( $ref, ( len( $ref ) - 1 ) ) };
 		//resolve internal refrences before looking for externals
-		if( left( $ref, 1 ) == chr( 35 )){
+        } else if( left( $ref, 1 ) == chr( 35 )){
 			var FilePath = "";
 			var XPath = right( $ref, len( $ref ) - 1 );
 		} else {

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -173,7 +173,7 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 
-			var compositionKeys = [ "$allOf", "$oneOf" ];
+			var compositionKeys = [ "$extend", "$allOf", "$oneOf" ]; // deprecated: $allOf, $oneOf
 
 			for( var composition in compositionKeys ){
 
@@ -214,9 +214,7 @@ component name="OpenAPIParser" accessors="true" {
      * @objects
      */
     function extendObject( array objects ) {
-        var output = {
-            "type": "object"
-        };
+        var output = {};
         objects.each( function( item, index ) {
             if ( isStruct( item ) ) {
 			

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -312,7 +312,12 @@ component name="OpenAPIParser" accessors="true" {
 
 		} catch( any e ){
 
-			throw(
+            // if this is a known exception or occured via recursion, rethrow the exception so the user knows which JSON file triggered it
+			if ( listFindNoCase( "SwaggerSDK.ParserException,CBSwagger.InvalidReferenceDocumentException", e.type ) ) {
+                rethrow;
+            }
+            
+            throw(
 				type="CBSwagger.InvalidReferenceDocumentException",
 				message="The $ref file pointer of #$ref# could not be loaded and parsed as a valid object.  If your $ref file content is an array, please nest the array within an object as a named key."
 			);

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -133,7 +133,14 @@ component name="OpenAPIParser" accessors="true" {
 		} else if( isStruct( DocItem ) ) {
 
             //handle top-level values, if they exist
-			if( structKeyExists( DocItem, "$ref" ) ) return fetchDocumentReference( DocItem[ "$ref" ] );
+			if( structKeyExists( DocItem, "$ref" ) ) {
+                // special handling for double pound signs
+                if( left( DocItem[ "$ref" ], 2 ) == chr( 35 ) & chr( 35 ) ) {
+                    DocItem[ "$ref" ] = right( DocItem[ "$ref" ], ( len( DocItem[ "$ref" ] ) - 1 ) );
+                    return DocItem;
+                }
+                return fetchDocumentReference( DocItem[ "$ref" ] );
+            }
 
 			for( var key in DocItem){
 
@@ -273,8 +280,14 @@ component name="OpenAPIParser" accessors="true" {
 	**/
 	private function fetchDocumentReference( required string $ref ){
 
+        /* if ( $ref == chr( 35 ) & chr( 35 ) & "/components/requestBodies/PostBody" ) {
+            writeDump( var=$ref, output="console" );
+        } */
+        
+        
         // double pound ## means we want to preserve the swagger $ref pointer (just remove the extra #)
         if( left( $ref, 2 ) == chr( 35 ) & chr( 35 ) ){
+            writeDump( var=right( $ref, ( len( $ref ) - 1 ) ), output="console" );
             return  { "$ref": right( $ref, ( len( $ref ) - 1 ) ) };
 		//resolve internal refrences before looking for externals
         } else if( left( $ref, 1 ) == chr( 35 )){

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -160,7 +160,7 @@ component name="OpenAPIParser" accessors="true" {
 
 
     /**
-	* Parses API Document $allOf notations recursively
+	* Parses API Document $extend notations recursively
 	*
 	* @param APIDoc		The struct representation of the API Document
 	* @param [XPath]	The XPath to zoom the parsed document to during recursion
@@ -173,7 +173,8 @@ component name="OpenAPIParser" accessors="true" {
 			}
 		} else if( isStruct( DocItem ) ) {
 
-			var compositionKeys = [ "$extend", "$allOf", "$oneOf" ]; // deprecated: $allOf, $oneOf
+			// $extend is a special key which enables merging json structs
+            var compositionKeys = [ "$extend" ];
 
 			for( var composition in compositionKeys ){
 

--- a/models/OpenAPI/Parser.cfc
+++ b/models/OpenAPI/Parser.cfc
@@ -143,7 +143,7 @@ component name="OpenAPIParser" accessors="true" {
 					structKeyExists( DocItem[ key ], "$ref" )
 				) {
 
-					DocItem[ key ] = fetchDocumentReference( DocItem[ key ][ "$ref" ] );
+					DocItem[ key ] = parseDocumentReferences( fetchDocumentReference( DocItem[ key ][ "$ref" ] ) );
 
 				} else if( isStruct( DocItem[ key ] ) ||  isArray( DocItem[ key ] ) ){
 
@@ -193,9 +193,9 @@ component name="OpenAPIParser" accessors="true" {
 						structKeyExists( DocItem[ key ], composition ) &&
 						isArray( DocItem[ key ][ composition ] )
 					) {
-						DocItem[ key ] = parseDocumentReferences( extendObject( DocItem[ key ][ composition ] ) );
+						DocItem[ key ] = extendObject( DocItem[ key ][ composition ] );
 					} else if( isStruct( DocItem[ key ] ) ||  isArray( DocItem[ key ] ) ){
-						DocItem[ key ] = parseDocumentInheritance( parseDocumentReferences( DocItem[ key ] ) );
+						DocItem[ key ] = parseDocumentInheritance( DocItem[ key ] );
 					}
 
 				}

--- a/test-harness/tests/resources/coldboxRest/_examples/response.json
+++ b/test-harness/tests/resources/coldboxRest/_examples/response.json
@@ -1,0 +1,9 @@
+{
+    "summary": "Response",
+    "description": "A generic response",
+    "value": {
+        "error": false,
+        "data": {},
+        "messages": []
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/_schemas/pagination.json
+++ b/test-harness/tests/resources/coldboxRest/_schemas/pagination.json
@@ -1,0 +1,25 @@
+{
+	"type": "object",
+	"properties": {
+		"maxRows": {
+			"description": "Maximum number of rows returned.",
+			"type": "integer"
+		},
+		"totalPages": {
+			"description": "Total pages available.",
+			"type": "integer"
+		},
+        "offset": {
+			"description": "Number of rows skipped.",
+			"type": "integer"
+		},
+        "page": {
+			"description": "Current page number.",
+			"type": "integer"
+		},
+		"totalRecords": {
+			"description": "Total number of records available.",
+			"type": "integer"
+		}
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/_schemas/response.json
+++ b/test-harness/tests/resources/coldboxRest/_schemas/response.json
@@ -1,0 +1,21 @@
+{
+    "type": "object",
+    "properties": {
+        "error": {
+            "description": "Flag to indicate an error.",
+            "type": "boolean"
+        },
+        "messages": {
+            "description": "An array of messages related to the request.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "data": {
+            "description": "The data packet",
+            "type": "object",
+            "properties": {}
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/coldboxRest.json
+++ b/test-harness/tests/resources/coldboxRest/coldboxRest.json
@@ -55,10 +55,13 @@
             "PostBody": { "$ref": "paths/posts/_schemas/postBody.json" },
             "Media": { "$ref": "paths/media/_schemas/media.json" },
             "BookMedia": { "$ref": "paths/media/_schemas/bookMedia.json" },
-            "MusicMedia": { "$ref": "paths/media/_schemas/musicMedia.json" }
+            "MusicMedia": { "$ref": "paths/media/_schemas/musicMedia.json" },
+            "BookMediaBody": { "$ref": "paths/media/_schemas/bookMediaBody.json" },
+            "MusicMediaBody": { "$ref": "paths/media/_schemas/musicMediaBody.json" }
         },
         "requestBodies": {
-            "PostBody": { "$ref": "paths/posts/_bodies/postBody.json" }
+            "PostBody": { "$ref": "paths/posts/_bodies/postBody.json" },
+            "MediaBody": { "$ref": "paths/media/_bodies/mediaBody.json" }
         }
     },
 	"paths": {

--- a/test-harness/tests/resources/coldboxRest/coldboxRest.json
+++ b/test-harness/tests/resources/coldboxRest/coldboxRest.json
@@ -1,0 +1,67 @@
+{
+	"openapi": "3.0.2",
+	"info": {
+		"title": "Coldbox Rest - OpenAPI 3.0",
+		"description": "This is a sample coldbox rest application",
+		"termsOfService": "",
+		"contact": {
+			"email": "apiteam@swagger.io"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+		},
+		"version": "1.0.17"
+	},
+	"externalDocs": {
+		"description": "Find out more about Swagger",
+		"url": "http://swagger.io"
+	},
+	"servers": [
+		{
+			"url": "/api/v3"
+		},
+        {
+			"url": "/api/v2"
+		}
+	],
+	"tags": [
+		{
+			"name": "users",
+			"description": "Operations about users"
+		},
+        {
+			"name": "posts",
+			"description": "Operations about posts"
+		},
+        {
+			"name": "media",
+			"description": "Operations about media"
+		}
+	],
+    "components": {
+        "securitySchemes": {
+            "APIKey" : {
+                "type" 			: "apiKey",
+                "description" 	: "Bearer Token",
+                "name" 			: "Authorization: Bearer",
+                "in" 			: "header"
+            }
+        },
+        "schemas": {
+            "Pagination": { "$ref": "_schemas/pagination.json" },
+            "User": { "$ref": "paths/users/_schemas/user.json" },
+            "Post": { "$ref": "paths/posts/_schemas/post.json" },
+            "Media": { "$ref": "paths/media/_schemas/media.json" },
+            "BookMedia": { "$ref": "paths/media/_schemas/bookMedia.json" },
+            "MusicMedia": { "$ref": "paths/media/_schemas/musicMedia.json" }
+        }
+    },
+	"paths": {
+        "$extend": [
+            { "$ref": "paths/users/users.json" },
+            { "$ref": "paths/posts/posts.json" },
+            { "$ref": "paths/media/media.json" }
+        ]
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/coldboxRest.json
+++ b/test-harness/tests/resources/coldboxRest/coldboxRest.json
@@ -52,9 +52,13 @@
             "Pagination": { "$ref": "_schemas/pagination.json" },
             "User": { "$ref": "paths/users/_schemas/user.json" },
             "Post": { "$ref": "paths/posts/_schemas/post.json" },
+            "PostBody": { "$ref": "paths/posts/_schemas/postBody.json" },
             "Media": { "$ref": "paths/media/_schemas/media.json" },
             "BookMedia": { "$ref": "paths/media/_schemas/bookMedia.json" },
             "MusicMedia": { "$ref": "paths/media/_schemas/musicMedia.json" }
+        },
+        "requestBodies": {
+            "PostBody": { "$ref": "paths/posts/_bodies/postBody.json" }
         }
     },
 	"paths": {

--- a/test-harness/tests/resources/coldboxRest/paths/media/_bodies/mediaBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_bodies/mediaBody.json
@@ -1,0 +1,18 @@
+{
+    "description": "Media to Create",
+    "required": true,
+    "content": {
+        "application/json": {
+            "schema": { 
+                "anyOf": [
+                    { "$ref": "##/components/schemas/MusicMediaBody" },
+                    { "$ref": "##/components/schemas/BookMediaBody" }
+                ]
+            },
+            "examples":  {
+                "MusicMediaBody": { "$ref": "../_examples/musicMediaBody.json" },
+                "BookMediaBody": { "$ref": "../_examples/bookMediaBody.json" }
+            }
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_examples/bookMediaBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_examples/bookMediaBody.json
@@ -1,0 +1,9 @@
+{
+    "summary": "BookMediaBody",
+    "description": "An example book media",
+    "value": {
+        "title": "Book Title",
+        "type": "book",
+        "isbn": "12345678"
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_examples/musicMediaBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_examples/musicMediaBody.json
@@ -1,0 +1,9 @@
+{
+    "summary": "MusicMediaBody",
+    "description": "An example music media",
+    "value": {
+        "title": "Music Title",
+        "type": "music",
+        "artist": "Music Artist"
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_responses/mediaResponse.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_responses/mediaResponse.json
@@ -1,0 +1,21 @@
+{
+    "$extend": [ 
+        {
+            "$ref": "../../../_schemas/response.json"
+        }, 
+        {
+            "properties": {
+                "data": {
+                    "oneOf": [
+                        { "$ref": "##/components/schemas/BookMedia" },
+                        { "$ref": "##/components/schemas/MusicMedia" }
+                    ],
+                    "discriminator": {
+                        "propertyName": "type"
+                    }
+                }
+            }
+        }   
+        
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_schemas/bookMedia.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_schemas/bookMedia.json
@@ -1,0 +1,13 @@
+{
+    "allOf": [
+        { "$ref": "##/components/schemas/Media" },
+        {
+            "type": "object",
+            "properties": {
+                "isbn": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_schemas/bookMediaBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_schemas/bookMediaBody.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string"
+        },
+        "isbn": {
+            "type": "string"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_schemas/media.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_schemas/media.json
@@ -1,0 +1,14 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_schemas/musicMedia.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_schemas/musicMedia.json
@@ -1,0 +1,13 @@
+{
+    "allOf": [
+        { "$ref": "##/components/schemas/Media" },
+        {
+            "type": "object",
+            "properties": {
+                "artist": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/_schemas/musicMediaBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/_schemas/musicMediaBody.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "type": {
+            "type": "string"
+        },
+        "artist": {
+            "type": "string"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/create/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/create/example.200.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "id": "1",
+        "title": "The Great Gatsby",
+        "type": "book",
+        "isbn": "1234567"
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/create/requestBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/create/requestBody.json
@@ -1,0 +1,18 @@
+{
+    "description": "Media to Create",
+    "required": true,
+    "content": {
+        "application/json": {
+            "schema": {
+                "anyOf": [
+                    { "$ref": "##/components/schemas/BookMediaBody" },
+                    { "$ref": "##/components/schemas/MusicMediaBody" }
+                ]
+            },
+            "examples": {
+                "BookMediaBody": { "$ref": "../_examples/bookMediaBody.json" },
+                "MusicMediaBody": { "$ref": "../_examples/musicMediaBody.json" }
+            }
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/create/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/create/responses.json
@@ -1,0 +1,15 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$ref": "../_responses/mediaResponse.json"
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/index/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/index/example.200.json
@@ -1,0 +1,27 @@
+{
+    "data": {
+        "pagination": {
+            "maxRows": 100,
+            "totalPages": 10,
+            "offset": 0,
+            "page": 1,
+            "totalRecords": 1000
+        },
+        "results": [
+            {
+                "id": "1",
+                "title": "The Great Gatsby",
+                "type": "book",
+                "isbn": "1234567"
+            },
+            {
+                "id": "2",
+                "title": "Today",
+                "type": "music",
+                "artist": "Smashing Pumpkins"
+            }
+        ]
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/index/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/index/parameters.json
@@ -1,0 +1,24 @@
+{
+    "parameters": [
+        {
+            "name": "pageSize",
+            "description": "The number of items per page",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 25
+            }
+        },
+        {
+            "name": "pageNumber",
+            "description": "The page of items to return",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 1
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/index/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/index/responses.json
@@ -1,0 +1,47 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        { 
+                            "type": "object" 
+                        },
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "anyOf": [
+                                                    { "$ref": "##/components/schemas/BookMedia" },
+                                                    { "$ref": "##/components/schemas/MusicMedia" }
+                                                ],
+                                                "discriminator": {
+                                                    "propertyName": "type"
+                                                }
+                                            }
+                                        },
+                                        "pagination": {
+                                            "$ref": "##/components/schemas/Pagination"
+                                        }
+                                    }
+                                }
+                            }
+                        }    
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/media.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/media.json
@@ -10,6 +10,17 @@
             "responses": {
                 "$ref": "index/responses.json"
             }
+        },
+        "post": {
+            "summary": "Create media",
+            "operationId": "media.create",
+            "tags": ["media"],
+            "requestBody": {
+                "$ref": "create/requestBody.json"
+            },
+            "responses": {
+                "$ref": "create/responses.json"
+            }
         } 
     },
     "/media/{id}": {

--- a/test-harness/tests/resources/coldboxRest/paths/media/media.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/media.json
@@ -1,0 +1,28 @@
+{
+    "/media": {
+        "get": {
+            "summary": "Paginate media",
+            "operationId": "media.index",
+            "tags": ["media"],
+            "parameters": {
+                "$ref": "index/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "index/responses.json"
+            }
+        } 
+    },
+    "/media/{id}": {
+        "get": {
+            "summary": "Show a media item",
+            "operationId": "media.show",
+            "tags": ["media"],
+            "parameters": {
+                "$ref": "show/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "show/responses.json"
+            }
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/show/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/show/example.200.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "id": "1",
+        "title": "The Great Gatsby",
+        "type": "book",
+        "isbn": "1234567"
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/show/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/show/parameters.json
@@ -1,0 +1,13 @@
+{
+    "parameters": [
+        {
+            "name": "id",
+            "description": "The id of the record to show",
+            "in": "path",
+            "required": true,
+            "schema": {
+                "type": "integer"
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/media/show/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/media/show/responses.json
@@ -1,0 +1,33 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "oneOf": [
+                                        { "$ref": "##/components/schemas/BookMedia" },
+                                        { "$ref": "##/components/schemas/MusicMedia" }
+                                    ],
+                                    "discriminator": {
+                                        "propertyName": "type"
+                                    }
+                                }
+                            }
+                        }   
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/_bodies/postBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/_bodies/postBody.json
@@ -1,0 +1,15 @@
+{
+    "description": "Post to Create",
+    "required": true,
+    "content": {
+        "application/json": {
+            "schema": { "$ref": "##/components/schemas/PostBody" },
+            "example":  {
+                "id": "1",
+                "title": "Washingtons Newburgh Address",
+                "body": "While I give you these assurances...",
+                "authorId": 1 
+            }
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/_schemas/post.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/_schemas/post.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "body": {
+            "type": "string"
+        },
+        "author": {
+            "$ref": "#/components/schemas/User"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/_schemas/postBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/_schemas/postBody.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "body": {
+            "type": "string"
+        },
+        "authorId": {
+            "type": "integer"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/create/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/create/example.200.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "id": "1",
+        "title": "Washingtons Newburgh Address",
+        "body": "While I give you these assurances, and pledge myself in the most unequivocal manner, to exert whatever ability I am possessed of, in your favor—let me entreat you, Gentlemen, on your part, not to take any measures, which, viewed in the calm light of reason, will lessen the dignity, & sully the glory you have hitherto maintained—let me request you to rely on the plighted faith of your Country, and place a full confidence in the purity of the intentions of Congress",
+        "author": {
+            "id": "1",
+            "firstName": "George",
+            "lastName": "Washington",
+            "emailAddress": "potus1@gmail.com"
+        }
+    },
+    "messages": [
+        "New Post Created Successfully"
+    ],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/create/requestBody.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/create/requestBody.json
@@ -1,0 +1,3 @@
+{
+    "$ref": "##/components/requestBodies/PostBody"
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/create/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/create/responses.json
@@ -1,0 +1,27 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "$ref": "##/components/schemas/Post" 
+                                }
+                            }
+                        }   
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/index/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/index/example.200.json
@@ -29,7 +29,7 @@
                     "lastName": "Washington",
                     "emailAddress": "potus1@gmail.com"
                 }
-            },
+            }
         ]
     },
     "messages": [],

--- a/test-harness/tests/resources/coldboxRest/paths/posts/index/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/index/example.200.json
@@ -1,0 +1,37 @@
+{
+    "data": {
+        "pagination": {
+            "maxRows": 100,
+            "totalPages": 10,
+            "offset": 0,
+            "page": 1,
+            "totalRecords": 1000
+        },
+        "results": [
+            {
+                "id": "1",
+                "title": "Washingtons Newburgh Address",
+                "body": "While I give you these assurances, and pledge myself in the most unequivocal manner, to exert whatever ability I am possessed of, in your favor—let me entreat you, Gentlemen, on your part, not to take any measures, which, viewed in the calm light of reason, will lessen the dignity, & sully the glory you have hitherto maintained—let me request you to rely on the plighted faith of your Country, and place a full confidence in the purity of the intentions of Congress",
+                "author": {
+                    "id": "1",
+                    "firstName": "George",
+                    "lastName": "Washington",
+                    "emailAddress": "potus1@gmail.com"
+                }
+            },
+            {
+                "id": "2",
+                "title": "Washingtons Inaugural Address",
+                "body": "I dwell on this prospect with every satisfaction which an ardent love for my Country can inspire: since there is no truth more thoroughly established, than that there exists in the economy and course of nature, an indissoluble union between virtue and happiness, between duty and advantage, between the genuine maxims of an honest and magnanimous policy, and the solid rewards of public prosperity and felicity: Since we ought to be no less persuaded that the propitious smiles of Heaven, can never be expected on a nation that disregards the eternal rules of order and right, which Heaven itself has ordained: And since the preservation of the sacred fire of liberty, and the destiny of the Republican model of Government, are justly considered as deeply, perhaps as finally staked, on the experiment entrusted to the hands of the American people",
+                "author": {
+                    "id": "1",
+                    "firstName": "George",
+                    "lastName": "Washington",
+                    "emailAddress": "potus1@gmail.com"
+                }
+            },
+        ]
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/index/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/index/parameters.json
@@ -1,0 +1,24 @@
+{
+    "parameters": [
+        {
+            "name": "pageSize",
+            "description": "The number of items per page",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 25
+            }
+        },
+        {
+            "name": "pageNumber",
+            "description": "The page of items to return",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 1
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/index/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/index/responses.json
@@ -1,0 +1,41 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        { 
+                            "type": "object" 
+                        },
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "##/components/schemas/Post" 
+                                            }
+                                        },
+                                        "pagination": {
+                                            "$ref": "##/components/schemas/Pagination"
+                                        }
+                                    }
+                                }
+                            }
+                        }    
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/posts.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/posts.json
@@ -1,0 +1,28 @@
+{
+    "/posts": {
+        "get": {
+            "summary": "Paginate posts",
+            "operationId": "posts.index",
+            "tags": ["posts"],
+            "parameters": {
+                "$ref": "index/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "index/responses.json"
+            }
+        } 
+    },
+    "/posts/{id}": {
+        "get": {
+            "summary": "Show a post",
+            "operationId": "posts.show",
+            "tags": ["posts"],
+            "parameters": {
+                "$ref": "show/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "show/responses.json"
+            }
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/posts.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/posts.json
@@ -10,6 +10,17 @@
             "responses": {
                 "$ref": "index/responses.json"
             }
+        }, 
+        "post": {
+            "summary": "Create a post",
+            "operationId": "posts.create",
+            "tags": ["posts"],
+            "requestBody": {
+                "$ref": "create/requestBody.json"
+            },
+            "responses": {
+                "$ref": "create/responses.json"
+            }
         } 
     },
     "/posts/{id}": {

--- a/test-harness/tests/resources/coldboxRest/paths/posts/show/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/show/example.200.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "1",
+        "title": "Washingtons Newburgh Address",
+        "body": "While I give you these assurances, and pledge myself in the most unequivocal manner, to exert whatever ability I am possessed of, in your favor—let me entreat you, Gentlemen, on your part, not to take any measures, which, viewed in the calm light of reason, will lessen the dignity, & sully the glory you have hitherto maintained—let me request you to rely on the plighted faith of your Country, and place a full confidence in the purity of the intentions of Congress",
+        "author": {
+            "id": "1",
+            "firstName": "George",
+            "lastName": "Washington",
+            "emailAddress": "potus1@gmail.com"
+        }
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/show/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/show/parameters.json
@@ -1,0 +1,13 @@
+{
+    "parameters": [
+        {
+            "name": "id",
+            "description": "The id of the record to show",
+            "in": "path",
+            "required": true,
+            "schema": {
+                "type": "integer"
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/posts/show/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/posts/show/responses.json
@@ -1,0 +1,27 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "$ref": "##/components/schemas/Post" 
+                                }
+                            }
+                        }   
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/_schemas/user.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/_schemas/user.json
@@ -1,0 +1,17 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "firstName": {
+            "type": "string"
+        },
+        "lastName": {
+            "type": "string"
+        },
+        "emailAddress": {
+            "type": "string"
+        }
+    }
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/index/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/index/example.200.json
@@ -1,0 +1,27 @@
+{
+    "data": {
+        "pagination": {
+            "maxRows": 100,
+            "totalPages": 10,
+            "offset": 0,
+            "page": 1,
+            "totalRecords": 1000
+        },
+        "results": [
+            {
+                "id": "1",
+                "firstName": "George",
+                "lastName": "Washington",
+                "emailAddress": "potus1@gmail.com"
+            },
+            {
+                "id": "2",
+                "firstName": "John",
+                "lastName": "Adams",
+                "emailAddress": "potus2@gmail.com"
+            } 
+        ]
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/index/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/index/parameters.json
@@ -1,0 +1,24 @@
+{
+    "parameters": [
+        {
+            "name": "pageSize",
+            "description": "The number of items per page",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 25
+            }
+        },
+        {
+            "name": "pageNumber",
+            "description": "The page of items to return",
+            "in": "query",
+            "required": false,
+            "schema": {
+                "type": "integer",
+                "default": 1
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/index/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/index/responses.json
@@ -1,0 +1,41 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        { 
+                            "type": "object" 
+                        },
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "../_schemas/user.json" 
+                                            }
+                                        },
+                                        "pagination": {
+                                            "$ref": "##/components/schemas/Pagination"
+                                        }
+                                    }
+                                }
+                            }
+                        }    
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/show/example.200.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/show/example.200.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "id": "1",
+        "firstName": "George",
+        "lastName": "Washington",
+        "emailAddress": "potus@gmail.com"
+    },
+    "messages": [],
+    "error": false
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/show/parameters.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/show/parameters.json
@@ -1,0 +1,13 @@
+{
+    "parameters": [
+        {
+            "name": "id",
+            "description": "The id of the record to show",
+            "in": "path",
+            "required": true,
+            "schema": {
+                "type": "integer"
+            }
+        }
+    ]
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/show/responses.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/show/responses.json
@@ -1,0 +1,27 @@
+{
+    "200": {
+        "description": "Success",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$extend": [ 
+                        {
+                            "$ref": "../../../_schemas/response.json"
+                        }, 
+                        {
+                            "properties": {
+                                "data": {
+                                    "$ref": "##/components/schemas/User" 
+                                }
+                            }
+                        }   
+                        
+                    ]
+				},
+                "example": {
+					"$ref": "example.200.json"
+				}
+            }
+        }
+	}
+}

--- a/test-harness/tests/resources/coldboxRest/paths/users/users.json
+++ b/test-harness/tests/resources/coldboxRest/paths/users/users.json
@@ -1,0 +1,28 @@
+{
+    "/users": {
+        "get": {
+            "summary": "Paginate users",
+            "operationId": "users.index",
+            "tags": ["users"],
+            "parameters": {
+                "$ref": "index/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "index/responses.json"
+            }
+        }
+    },
+    "/users/{id}": {
+        "get": {
+            "summary": "Show a user",
+            "operationId": "users.show",
+            "tags": ["users"],
+            "parameters": {
+                "$ref": "show/parameters.json#/parameters"
+            },
+            "responses": {
+                "$ref": "show/responses.json"
+            }
+        }
+    }
+}

--- a/test-harness/tests/specs/ColdboxSpec.cfc
+++ b/test-harness/tests/specs/ColdboxSpec.cfc
@@ -45,6 +45,8 @@ component extends="BaseOpenAPISpec"{
 			it( "Can parse the apiDoc", function(){
 				var apiDoc = parseApiDoc();
 
+                debug( serializeJson( apiDoc ) );
+
                 // it can have multiple servers
                 expect( apiDoc ).toHaveKey( "servers" );
                 expect( apiDoc.servers ).toBeArray();
@@ -94,6 +96,10 @@ component extends="BaseOpenAPISpec"{
                 for ( var item in expectedKeys ) {
                     expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties.results.items.properties ).toHaveKey( item );
                 }
+
+                // expect the requestBody reference to have one pound sign
+                expect( apiDoc.paths[ "/posts" ].post.requestBody ).toHaveKey( "$ref" );
+                expect( left( apiDoc.paths[ "/posts" ].post.requestBody[ '$ref' ], 2 ) ).toBe( "#chr( 35 )#/" );
 
 			});
 

--- a/test-harness/tests/specs/ColdboxSpec.cfc
+++ b/test-harness/tests/specs/ColdboxSpec.cfc
@@ -45,8 +45,6 @@ component extends="BaseOpenAPISpec"{
 			it( "Can parse the apiDoc", function(){
 				var apiDoc = parseApiDoc();
 
-                debug( serializeJson( apiDoc ) );
-
                 // it can have multiple servers
                 expect( apiDoc ).toHaveKey( "servers" );
                 expect( apiDoc.servers ).toBeArray();

--- a/test-harness/tests/specs/ColdboxSpec.cfc
+++ b/test-harness/tests/specs/ColdboxSpec.cfc
@@ -1,0 +1,103 @@
+/**
+* My BDD Test
+*/
+component extends="BaseOpenAPISpec"{
+
+    public function beforeAll(){
+        super.beforeAll();
+
+        variables.testJSONAPIDIrectory = expandPath( "/tests/resources/coldboxRest" );
+
+        expect( directoryExists( testJSONAPIDIrectory ) ).toBeTrue(
+            "The test JSON API directory does not exist. Could not continue."
+        );
+
+        expect(
+            fileExists(
+                testJSONAPIDIrectory & "/" & listLast( testJSONAPIDIrectory, "/\" ) & ".json"
+            )
+        ).toBeTrue(
+            "A JSON API file named #listLast( testJSONAPIDIrectory, "/\" ) & ".json"# does not exist in the #testJSONAPIDIrectory# directory.  Could not continue."
+        );
+
+        VARIABLES.testJSONFile = testJSONAPIDIrectory & "/" & listLast(
+            testJSONAPIDIrectory,
+            "/\"
+        ) & ".json";
+    }
+
+    struct function parseApiDoc() {
+        var parser = getInstance( "OpenAPIParser@SwaggerSDK" ).init( VARIABLES.TestJSONFile );
+        var parserDoc = parser.getDocumentObject();
+        return parserDoc.getNormalizedDocument();
+    }
+
+/*********************************** BDD SUITES ***********************************/
+
+	function run(){
+		// all your suites go here.
+		describe( "Performs and tests common Coldbox Restful app functionality" ,function(){
+
+			beforeEach(function( currentSpec ){
+				setup();
+			});
+
+			it( "Can parse the apiDoc", function(){
+				var apiDoc = parseApiDoc();
+
+                // it can have multiple servers
+                expect( apiDoc ).toHaveKey( "servers" );
+                expect( apiDoc.servers ).toBeArray();
+                expect( apiDoc.servers.len() ).toBe( 2 );
+
+                // it has multiple paths produced by $extend
+                expect( apiDoc ).toHaveKey( "paths" );
+                expect( apiDoc.paths ).toHaveKey( "/users" );
+                expect( apiDoc.paths ).toHaveKey( "/posts" );
+
+                // schema: expectations
+                expect( apiDoc.components ).toHaveKey( "schemas" );
+                expect( apiDoc.components.schemas ).toHaveKey( "Pagination" );
+                expect( apiDoc.components.schemas ).toHaveKey( "User" );
+                expect( apiDoc.components.schemas ).toHaveKey( "Post" );
+                expect( apiDoc.components.schemas ).toHaveKey( "Media" );
+                
+                // schema inherited objects via `allOf`
+                var childObjects = [ "BookMedia", "MusicMedia" ];
+
+                for ( var item in ChildObjects ) {
+                    expect( apiDoc.components.schemas ).toHaveKey( item );
+                    expect( apiDoc.components.schemas[ item ] ).toHaveKey( "allOf" );
+                    expect( apiDoc.components.schemas[ item ].allOf ).toBeArray(); 
+                    expect( apiDoc.components.schemas[ item ].allOf[ 1 ] ).toBeStruct(); 
+                    expect( apiDoc.components.schemas[ item ].allOf[ 1 ] ).toHaveKey( "$ref" );
+                    expect( apiDoc.components.schemas[ item ].allOf[ 1 ][ "$ref" ] ).toBe( "##/components/schemas/Media" ); 
+                }
+
+                // users.index intentionally doesn't use components/schema. Check for existence of $ref object
+                expect( apiDoc.paths[ "/users" ] ).toHaveKey( "get" );
+                expect( apiDoc.paths[ "/users" ].get ).toHaveKey( "responses" );
+                expect( apiDoc.paths[ "/users" ].get.responses ).toHaveKey( "200" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ] ).toHaveKey( "content" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content ).toHaveKey( "application/json" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ] ).toHaveKey( "schema" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema ).toHaveKey( "properties" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties ).toHaveKey( "data" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data ).toHaveKey( "properties" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties ).toHaveKey( "results" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties ).toHaveKey( "pagination" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties.results ).toHaveKey( "items" );
+                expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties.results.items ).toHaveKey( "properties" );
+
+                var expectedKeys = [ "id", "firstName", "lastName" ];
+
+                for ( var item in expectedKeys ) {
+                    expect( apiDoc.paths[ "/users" ].get.responses[ "200" ].content[ "application/json" ].schema.properties.data.properties.results.items.properties ).toHaveKey( item );
+                }
+
+			});
+
+		});
+	}
+
+}

--- a/test-harness/tests/specs/ParserSpec.cfc
+++ b/test-harness/tests/specs/ParserSpec.cfc
@@ -58,19 +58,15 @@ component extends="BaseOpenAPISpec"{
 	function runParserRecursionTests( required Parser, required boolean testObjects=false ){
 		if( ARGUMENTS.testObjects ){
 
-			it( "Tests for the recursive presence of OpenAPIDocument objects within Parser #Parser.getSchemaType()# document object" , function(){
+			it( "Tests for the recursive presence of structs within Parser #Parser.getSchemaType()# document object" , function(){
 				var ParserDoc = Parser.getDocumentObject();
 				expect( ParserDoc ).toBeInstanceOf( "Document" );
 				expect( ParserDoc ).toHaveKey( "getDocument" );
 				var APIDoc = ParserDoc.getDocument();
 				expect( APIDoc ).toBeStruct();
 				expect( APIDoc ).toHaveKey( "paths" );
-				expect( APIDoc.paths ).toBeInstanceOf( "Parser" );
-				runParserTypeChecks( APIDoc.paths );
-				var paths = APIDoc.paths.getDocumentObject().getNormalizedDocument();
-				expect( paths ).toHaveKey( "/pets" );
-
-
+				expect( APIDoc.paths ).toBeStruct();
+				expect( APIDoc.paths ).toHaveKey( "/pets" );
 			});
 
 		}

--- a/test-harness/tests/specs/ParserSpec.cfc
+++ b/test-harness/tests/specs/ParserSpec.cfc
@@ -101,7 +101,7 @@ component extends="BaseOpenAPISpec"{
 			expect( NormalizedDocument.paths[ '/pet/{petId}' ] ).toHaveDeepKey( "responses" );
 
 			expect( arrayLen( structFindKey( NormalizedDocument, "$ref" ) ) ).toBe( 0 );
-			expect( arrayLen( structFindKey( NormalizedDocument, "$allOf" ) ) ).toBe( 0 );
+            expect( arrayLen( structFindKey( NormalizedDocument, "$extend" ) ) ).toBe( 0 );
 
 		});
 


### PR DESCRIPTION
I spent a lot of time reviewing the Parser to figure out what was happening in the last update. I have isolated the problem, fixed it, made some improvements, and added a performance boost.

I also created a new test spec called ColdboxSpec, designed to test common use cases where Coldbox RESTful applications need to generate OpenApi (swagger) files.  Coldbox API's use different conventions than PetStore, and testing against these conventions can help prevent future issues and optimize development.

There is one breaking change in this patch compared with the development branch.  I consolidated the `$allOf` and `$oneOff` composition keys into a single key called `$extend`.   `$extend` is a better descriptor of how the process works because it _extends_ multiple JSON files and flattens them into a single object (similar to CFML's `structAppend()` or jQuery's `extend()`).  The terms `allOf` and `oneOf` were misleading because they are used by swagger files to denote _inheritance_ and _polymorphism_.  According to the OpenAPI specs, `allOf` can only be used in the `components.schemas` section of the swagger file.   This change should help avoid confusion moving forward.

## ColdBox Tests Spec:

Coldbox RESTful apps use a set of conventions to build out APIs, including a powerful base REST handler.  I felt it was important to build a test spec to emulate and check against a simulated typical Coldbox REST API's request and response structure.  The primary goals of the new test specs were to:
 - Optimize for model/object reuse across the docs
 - Minimize copy/pasting of boilerplate JSON data
 - Use a typical Coldbox REST handler naming convention to create common routes/endpoints
 - Utilize a combination of recursive `$ref` injections and internal references to account for coding preferences.
 - Utilize the new `$extend` key to build leaner swagger files.

I added a new folder to the test-harness/tests/resources/ folder called "coldboxRest". The structure should emulate a typical ColdBox app, with schemas, handlers (paths), responses, and examples.

I immediately noticed how clean the handler (path) JSON files became once I started using `$ref` annotations to point to internal and external references. Here's an example:
```
// posts.json
{
    "/posts": {
        "get": {
            "summary": "Paginate posts",
            "operationId": "posts.index",
            "tags": ["posts"],
            "parameters": {
                "$ref": "index/parameters.json#/parameters"
            },
            "responses": {
                "$ref": "index/responses.json"
            }
        } 
    },
    "/posts/{id}": {
        "get": {
            "summary": "Show a post",
            "operationId": "posts.show",
            "tags": ["posts"],
            "parameters": {
                "$ref": "show/parameters.json#/parameters"
            },
            "responses": {
                "$ref": "show/responses.json"
            }
        }
    }
}
```

I also accounted for different coding styles with `$ref` keys.  Some people inject every model directly into the response schema, whereas others prefer referencing models in the `components.schemas` section using the new double hash `##` annotation.

Here's an example of how both work:
```
// /paths/users/index/responses.json
{
  "200": {
    "description": "Success",
    "content": {
      "application/json": {
        "schema": {
          "$extend": [
            {
              "type": "object"
            },
            {
              "$ref": "../../../_schemas/response.json" <- injection
            },
            {
              "properties": {
                "data": {
                  "type": "object",
                  "properties": {
                    "results": {
                      "type": "array",
                      "items": {
                        "$ref": "../_schemas/user.json" <- injection
                      }
                    },
                    "pagination": {
                      "$ref": "##/components/schemas/Pagination" <- local reference
                    }
                  }
                }
              }
            }
          ]
        },
        "example": {
          "$ref": "example.200.json" <- injection
        }
      }
    }
  }
}
```

One of the things I feel ColdBox developers should use more is the OpenApi `components.schemas` definition section.  Not only does referencing existing models create smaller (and faster) swagger files, but it also mirrors the same development approach taught in the Ortus API master class where the models for the API live in the app's root (e.g. models/User.cfc), and the API REST handlers live in sub-modules (e.g. /api/v1/users).  Defining models/schemas in the swagger root feels like a best practice to me and I believe someday I can come up with a way to dynamically inject schemas into this section. The below snippet example is taken from the root coldboxRest.json file:

```
  "components": {
     "schemas": {
            "Pagination": { "$ref": "_schemas/pagination.json" },
            "User": { "$ref": "paths/users/_schemas/user.json" },
            "Post": { "$ref": "paths/posts/_schemas/post.json" },
            "Media": { "$ref": "paths/media/_schemas/media.json" },
            "BookMedia": { "$ref": "paths/media/_schemas/bookMedia.json" },
            "MusicMedia": { "$ref": "paths/media/_schemas/musicMedia.json" }
        }
    },
    "paths": {
        "$extend": [
            { "$ref": "paths/users/users.json" },
            { "$ref": "paths/posts/posts.json" },
            { "$ref": "paths/media/media.json" }
        ]
    }
```
Some people may argue that the root app shouldn't have any knowledge about anything going on in submodules. I agree with that statement, except that the root app still needs to know about dependencies (hence the box.json file), so I don't see why the root of the swagger can't list out schema dependencies in the same way.  Either way, with this patch, Coldbox developers should have a lot more flexibility with how they document their APIs.

One additional advantage of defining models in the `components.schemas` section is that UI tools that render swagger files can display all the schemas in a special easy-to-read section like this:

![image](https://user-images.githubusercontent.com/5341142/204676788-21d6bf48-119d-4efa-82bc-d0a66964e1b0.png)

Anyway, that's it! Hopefully, you feel these contributions have a positive impact on the project. :)